### PR TITLE
Add debug mode for gh requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/.idea

--- a/README.md
+++ b/README.md
@@ -90,9 +90,16 @@ Override the username or quota if needed:
 copilot-usage --username kevingosse --quota 1500
 ```
 
+Show each `gh` command and the raw API response for troubleshooting:
+
+```powershell
+copilot-usage --debug
+```
+
 ## Options
 
 - `--username <USER>`: GitHub username. If omitted, the tool tries `GITHUB_USER`, `GH_USERNAME`, then `gh api user --jq .login`
 - `--quota <N>`: monthly quota override, default `1500`
 - `--months <N>`: number of previous months to compare in `--full`, default `6`
 - `--full`: show the full dashboard with sparkline, previous months, and model breakdown
+- `--debug`: print each `gh` command plus raw stdout/stderr to `stderr`

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, process::Command, thread};
+use std::{collections::BTreeMap, thread};
 
 use chrono::{Datelike, NaiveDate};
 use serde_json::Value;
@@ -50,6 +50,7 @@ pub fn load_api_usage(
     today: NaiveDate,
     include_recent_daily: bool,
     include_previous_months: bool,
+    debug: bool,
 ) -> Result<UsageDataset, String> {
     let mut by_day: BTreeMap<NaiveDate, DailyUsage> = BTreeMap::new();
     let mut latest_quota: Option<(NaiveDate, f64)> = None;
@@ -70,6 +71,7 @@ pub fn load_api_usage(
             include_recent_daily,
             include_previous_months,
         ),
+        debug,
     )? {
         let rows = response.rows;
         match response.request.target {
@@ -170,6 +172,7 @@ fn recent_window_start_day(today: NaiveDate) -> u32 {
 fn execute_requests(
     username: &str,
     requests: Vec<FetchRequest>,
+    debug: bool,
 ) -> Result<Vec<FetchResponse>, String> {
     let mut responses = Vec::with_capacity(requests.len());
     let username = username.to_string();
@@ -187,6 +190,7 @@ fn execute_requests(
                             request.month,
                             request.day,
                             request.synthetic_date,
+                            debug,
                         )?;
                         Ok(FetchResponse {
                             request: request.clone(),
@@ -240,6 +244,7 @@ fn fetch_period(
     month: u32,
     day: Option<u32>,
     synthetic_date: NaiveDate,
+    debug: bool,
 ) -> Result<Vec<ApiRecord>, String> {
     let period_label = describe_period(year, month, day);
     let mut endpoint = format!(
@@ -249,19 +254,20 @@ fn fetch_period(
         endpoint.push_str(&format!("&day={day}"));
     }
 
-    let output = Command::new("gh")
-        .args([
-            "api",
-            "-H",
-            "Accept: application/vnd.github+json",
-            "-H",
-            &format!("X-GitHub-Api-Version: {API_VERSION}"),
-            &endpoint,
-        ])
-        .output()
-        .map_err(|error| {
-            format!("failed to run gh for {period_label}: {error}. Is GitHub CLI installed?")
-        })?;
+    let output = crate::gh::run_gh(
+        [
+            "api".to_string(),
+            "-H".to_string(),
+            "Accept: application/vnd.github+json".to_string(),
+            "-H".to_string(),
+            format!("X-GitHub-Api-Version: {API_VERSION}"),
+            endpoint.clone(),
+        ],
+        debug,
+    )
+    .map_err(|error| {
+        format!("failed to run gh for {period_label}: {error}. Is GitHub CLI installed?")
+    })?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);

--- a/src/gh.rs
+++ b/src/gh.rs
@@ -1,0 +1,116 @@
+use std::{
+    ffi::{OsStr, OsString},
+    io,
+    process::{Command, Output},
+    sync::{Mutex, OnceLock},
+};
+
+static DEBUG_OUTPUT_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+pub fn run_gh<I, S>(args: I, debug: bool) -> io::Result<Output>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let args: Vec<OsString> = args
+        .into_iter()
+        .map(|argument| argument.as_ref().to_os_string())
+        .collect();
+    let output = Command::new("gh").args(&args).output();
+
+    if debug {
+        log_command(&args, &output);
+    }
+
+    output
+}
+
+fn log_command(args: &[OsString], output: &io::Result<Output>) {
+    let guard = DEBUG_OUTPUT_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("debug output lock poisoned");
+
+    eprintln!("[debug] gh command: {}", format_command(args));
+
+    match output {
+        Ok(output) => {
+            print_stream("stdout", &output.stdout);
+            print_stream("stderr", &output.stderr);
+        }
+        Err(error) => {
+            eprintln!("[debug] failed to execute gh: {error}");
+        }
+    }
+
+    drop(guard);
+}
+
+fn print_stream(label: &str, bytes: &[u8]) {
+    eprintln!("[debug] gh {label}:");
+    if bytes.is_empty() {
+        eprintln!("<empty>");
+        return;
+    }
+
+    eprint!("{}", String::from_utf8_lossy(bytes));
+    if !bytes.ends_with(b"\n") {
+        eprintln!();
+    }
+}
+
+fn format_command(args: &[OsString]) -> String {
+    std::iter::once("gh".to_string())
+        .chain(
+            args.iter()
+                .map(|argument| quote_argument(&argument.to_string_lossy())),
+        )
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn quote_argument(argument: &str) -> String {
+    if !argument.is_empty()
+        && argument.chars().all(|character| {
+            character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.' | '/' | '\\')
+        })
+    {
+        argument.to_string()
+    } else {
+        format!("'{}'", argument.replace('\'', "''"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+
+    use super::format_command;
+
+    #[test]
+    fn leaves_simple_arguments_unquoted() {
+        let command = format_command(&[
+            OsString::from("api"),
+            OsString::from("user"),
+            OsString::from("--jq"),
+            OsString::from(".login"),
+        ]);
+
+        assert_eq!(command, "gh api user --jq .login");
+    }
+
+    #[test]
+    fn quotes_arguments_with_powershell_sensitive_characters() {
+        let command = format_command(&[
+            OsString::from("api"),
+            OsString::from("-H"),
+            OsString::from("Accept: application/vnd.github+json"),
+            OsString::from("/users/kevin/settings/billing/premium_request/usage?year=2026&month=3"),
+        ]);
+
+        assert_eq!(
+            command,
+            "gh api -H 'Accept: application/vnd.github+json' '/users/kevin/settings/billing/premium_request/usage?year=2026&month=3'"
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,10 @@
 mod analytics;
 mod api;
 mod display;
+mod gh;
 mod models;
 
-use std::{
-    env,
-    process::{Command, ExitCode},
-};
+use std::{env, process::ExitCode};
 
 use analytics::analyze_usage;
 use chrono::Utc;
@@ -36,6 +34,10 @@ struct Cli {
     /// Show the full dashboard with recent daily detail and previous months
     #[arg(long)]
     full: bool,
+
+    /// Print each gh command and its raw response to stderr
+    #[arg(long)]
+    debug: bool,
 }
 
 fn main() -> ExitCode {
@@ -58,8 +60,10 @@ fn run() -> Result<(), String> {
     }
     let today = Utc::now().date_naive();
 
-    let username = resolve_username(cli.username.as_deref())?;
-    let dataset = api::load_api_usage(&username, cli.quota, cli.months, today, cli.full, cli.full)?;
+    let username = resolve_username(cli.username.as_deref(), cli.debug)?;
+    let dataset = api::load_api_usage(
+        &username, cli.quota, cli.months, today, cli.full, cli.full, cli.debug,
+    )?;
 
     render(dataset, today, cli.months);
     Ok(())
@@ -70,7 +74,7 @@ fn render(dataset: UsageDataset, today: chrono::NaiveDate, previous_months: usiz
     println!("{}", display::render_report(&summary));
 }
 
-fn resolve_username(cli_username: Option<&str>) -> Result<String, String> {
+fn resolve_username(cli_username: Option<&str>, debug: bool) -> Result<String, String> {
     if let Some(username) = cli_username
         .map(str::trim)
         .filter(|value| !value.is_empty())
@@ -87,17 +91,14 @@ fn resolve_username(cli_username: Option<&str>) -> Result<String, String> {
         }
     }
 
-    infer_username_from_gh().ok_or_else(|| {
+    infer_username_from_gh(debug).ok_or_else(|| {
         "missing GitHub username (use --username, set GITHUB_USER/GH_USERNAME, or log in with gh)"
             .to_string()
     })
 }
 
-fn infer_username_from_gh() -> Option<String> {
-    let output = Command::new("gh")
-        .args(["api", "user", "--jq", ".login"])
-        .output()
-        .ok()?;
+fn infer_username_from_gh(debug: bool) -> Option<String> {
+    let output = crate::gh::run_gh(["api", "user", "--jq", ".login"], debug).ok()?;
     if !output.status.success() {
         return None;
     }


### PR DESCRIPTION
## Summary
- add a --debug mode that prints each gh command plus raw stdout/stderr
- route username lookup and billing requests through a shared helper so debug output is consistent even with concurrent requests
- ignore local .idea/ files

## Testing
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo build --verbose
- cargo test --verbose